### PR TITLE
Dismiss items if cleared by subscribers

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,3 +1,9 @@
+1.5.3 (unreleased)
+------------------
+
+- #31 Dismiss items if cleared by subscribers
+
+
 1.5.2 (2020-08-05)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-version = "1.5.2"
+version = "1.5.3"
 
 with open("docs/About.rst", "r") as fh:
     long_description = fh.read()

--- a/src/senaite/core/listing/view.py
+++ b/src/senaite/core/listing/view.py
@@ -900,6 +900,10 @@ class ListingView(AjaxListingView):
             for subscriber in self.get_listing_view_adapters():
                 subscriber.folder_item(obj, item, idx)
 
+            # Dismiss item if cleared by subscribers
+            if not item:
+                continue
+
             results.append(item)
             idx += 1
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Subscribes might want to omit an item to be rendered in the listing. They can do it by doing `item.clear()`. However, `senaite.core.listing` does not take this into consideration and adds the item to the records list. This has an undesired effect because of pagination: the listing ends up displaying less (or any) item because there were no chance to consider further brains while foldering.

## Current behavior before PR

When a subscriber clears an item (in `folder_item` function), the listing keeps adding it into the records.

## Desired behavior after PR is merged

When a subscriber clears an item, the listing dismiss the item and the index is not increased in one unit, so the pagination works as expected.

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
