### PR TITLE
Fix url auto-resolution when object's path starts with portal id

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.0.0rc3 (unreleased)
 ---------------------
 
+- #40 Fix url auto-resolution when object's path starts with portal id
 - #39 Less intrusive table-overlay on loading
 
 

--- a/src/senaite/app/listing/view.py
+++ b/src/senaite/app/listing/view.py
@@ -921,7 +921,7 @@ class ListingView(AjaxListingView):
         :param url_or_path: Absolute URL, physical path or relative path
         :returns: Absolute URL
         """
-        portal_path = api.get_path(self.portal)
+        portal_path = "{}/".format(api.get_path(self.portal))
         portal_url = api.get_url(self.portal)
 
         # remove the portal_url from the url_or_path


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

When an object's path starts with `senaite`, this part is removed when auto-resolving the url from the column properties.
For instance, an object with an url of  http://localhost:9090/senaite/senaite_storage/storagefacility-1/SC-00001 resolves to http://localhost:9090/senaite/_storage/storagefacility-1/SC-00001

This Pull Request closes https://github.com/senaite/senaite.storage/issues/17

## Current behavior before PR

URL's starting with same name as the portal id are not resolved correctly

## Desired behavior after PR is merged

URL's starting with same name as the portal id are resolved correctly

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
