### PR TITLE
Utility "add_column" without "after" or "before" arguments does not add the column

### DIFF
--- a/src/senaite/core/listing/utils.py
+++ b/src/senaite/core/listing/utils.py
@@ -73,12 +73,22 @@ def add_column(listing, column_id, column_values, before=None, after=None,
         raise ValueError("Column '{}' does not exist".format(after))
 
     new_dict = collections.OrderedDict()
+    inserted = False
+
     for key, item in listing.columns.copy().items():
         if before == key:
             new_dict[column_id] = column_values
+            inserted = True
         new_dict[key] = item
         if after == key:
             new_dict[column_id] = column_values
+            inserted = True
+
+    # If not not an "after" or "before" position was given, insert
+    # the column at the end
+    if not inserted:
+        new_dict[column_id] = column_values
+
     listing.columns = new_dict
 
     if not review_states:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`add_column` utility defines the following arguments:

`def add_column(listing, column_id, column_values, before=None, after=None, review_states=None)
`

Therefore, `before` and `after` are not required, but if they are not given, the column is not added and no warning is send to the developer.

## Current behavior before PR

If `before` or `after` arguments are not given, they are not included in the listing.

## Desired behavior after PR is merged

If `before` and `after`  are not given, the column is added at the end.

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
