### PR TITLE
Set ajax folderitems to a readonly transaction

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,7 @@
 2.0.0 (unreleased)
 ------------------
 
-- no changes yet
+- #49 Set ajax folderitems to a readonly transaction
 
 
 2.0.0rc3 (2021-01-04)

--- a/src/senaite/app/listing/ajax.py
+++ b/src/senaite/app/listing/ajax.py
@@ -38,6 +38,7 @@ from senaite.app.listing.decorators import returns_safe_json
 from senaite.app.listing.decorators import set_application_json_header
 from senaite.app.listing.decorators import translate
 from senaite.app.listing.interfaces import IAjaxListingView
+from senaite.core.decorators import readonly_transaction
 from zope import event
 from zope.interface import implements
 from zope.lifecycleevent import modified
@@ -501,6 +502,7 @@ class AjaxListingView(BrowserView):
         """
         raise NotImplementedError("Must be implemented by subclass")
 
+    @readonly_transaction
     @set_application_json_header
     @returns_safe_json
     @inject_runtime


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR is dependent on https://github.com/senaite/senaite.core/pull/1732

## Current behavior before PR

Fetching the listing folderitems via Ajax request always committed a transaction implicitly, which increased the possibility for DB conflict errors:

https://github.com/zopefoundation/ZServer/blob/master/src/ZServer/ZPublisher/Publish.py#L151

## Desired behavior after PR is merged

Fetching listing folderitems is decorated as `readonly_transaction`, which dooms the transaction:
https://transaction.readthedocs.io/en/latest/doom.html#dooming-transactions

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
