### PR TITLE
Improve fetch performance by marking readonly transactions explicitly

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.0.0 (unreleased)
 ------------------
 
+- #54 Improve fetch performance by marking readonly transactions explicitly
 - #51 Browser history aware listings
 - #50 Support child folder items to any depth
 - #49 Set ajax folderitems to a readonly transaction

--- a/src/senaite/app/listing/ajax.py
+++ b/src/senaite/app/listing/ajax.py
@@ -555,6 +555,7 @@ class AjaxListingView(BrowserView):
 
         return data
 
+    @readonly_transaction
     @set_application_json_header
     @returns_safe_json
     @inject_runtime
@@ -601,6 +602,7 @@ class AjaxListingView(BrowserView):
 
         return data
 
+    @readonly_transaction
     @set_application_json_header
     @returns_safe_json
     @inject_runtime
@@ -633,6 +635,7 @@ class AjaxListingView(BrowserView):
         }
         return data
 
+    @readonly_transaction
     @set_application_json_header
     @returns_safe_json
     @inject_runtime


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR marks the following fetch operations as readonly:

- ajax_transitions
- ajax_get_children
- ajax_query_folderitems

## Current behavior before PR

Implicit transaction commits happened at the end of the request

## Desired behavior after PR is merged

Transaction is doomed by the decorator and dropped

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
