### PR TITLE
Fix column not added when neither after nor before params are set

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,8 @@
 2.0.1 (unreleased)
 ------------------
 
+- #59 Fix column not added when neither after nor before params are set
+- #59 Fix review state not added when neither after nor before params are set
 
 
 2.0.0 (2021-07-26)

--- a/src/senaite/app/listing/utils.py
+++ b/src/senaite/app/listing/utils.py
@@ -36,6 +36,10 @@ def add_review_state(listing, review_state, before=None, after=None):
     if review_state["id"] in ids:
         return False
 
+    # If neither before nor after are set, add the review state at the end
+    if not any([before, after]):
+        after = ids[-1]
+
     if before and before not in ids:
         raise ValueError("Review state '{}' does not exist".format(before))
 
@@ -65,6 +69,10 @@ def add_column(listing, column_id, column_values, before=None, after=None,
     if column_id in ids:
         listing.columns[column_id].update(column_values)
         return True
+
+    # If neither before nor after are set, add the column at the end
+    if not any([before, after]):
+        after = ids[-1]
 
     if before and before not in ids:
         raise ValueError("Column '{}' does not exist".format(before))


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes `add_column` and `add_review_state` functions from `utils` package so the column (or review status) is added even if no after or event parameters are passed in.

## Current behavior before PR

Custom column is not added when neither after nor before params are set

## Desired behavior after PR is merged

Custom column is added (at the end) when neither after nor before params are set

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
