### PR TITLE
Make ajax functions to use readonly transactions (ports #49 and #54)

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,3 +1,8 @@
+1.5.4 (unreleased)
+------------------
+
+- #61 Make ajax functions to use readonly transactions (ports #49 and #54)
+
 1.5.3 (2021-07-24)
 ------------------
 

--- a/src/senaite/core/listing/ajax.py
+++ b/src/senaite/core/listing/ajax.py
@@ -27,6 +27,7 @@ import six
 from bika.lims import api
 from bika.lims import logger
 from bika.lims.browser import BrowserView
+from bika.lims.decorators import readonly_transaction
 from bika.lims.interfaces import IReferenceAnalysis
 from bika.lims.interfaces import IRoutineAnalysis
 from plone.memoize import view
@@ -496,6 +497,7 @@ class AjaxListingView(BrowserView):
         """
         raise NotImplementedError("Must be implemented by subclass")
 
+    @readonly_transaction
     @set_application_json_header
     @returns_safe_json
     @inject_runtime
@@ -550,6 +552,7 @@ class AjaxListingView(BrowserView):
 
         return data
 
+    @readonly_transaction
     @set_application_json_header
     @returns_safe_json
     @inject_runtime
@@ -596,6 +599,7 @@ class AjaxListingView(BrowserView):
 
         return data
 
+    @readonly_transaction
     @set_application_json_header
     @returns_safe_json
     @inject_runtime
@@ -632,6 +636,7 @@ class AjaxListingView(BrowserView):
 
         return data
 
+    @readonly_transaction
     @set_application_json_header
     @returns_safe_json
     @inject_runtime


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ports #49 and #54 to 1.x

## Current behavior before PR

ajax functions are not wrapped by the `readonly_transaction` decorator

## Desired behavior after PR is merged

ajax functions are wrapped by the `readonly_transaction` decorator

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
