### PR TITLE
Fix traceback when contentFilter's portal_type has a list/tuple defined

### DIFF
--- a/src/senaite/app/listing/view.py
+++ b/src/senaite/app/listing/view.py
@@ -728,6 +728,10 @@ class ListingView(AjaxListingView):
         index = None
         indexes = catalog.indexes()
         portal_type = self.contentFilter.get("portal_type", "")
+        if isinstance(portal_type, (list, tuple)):
+            portal_types = map(lambda pt: pt.lower(), portal_type)
+            portal_type = "_".join(sorted(portal_types))
+
         default_index = "listing_searchable_text"
         custom_type_index = "%s_searchable_text" % portal_type.lower()
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes possible to use lists/tuples for "portal_type" search criteria in `contentFilter` variable

## Current behavior before PR

A traceback arises when the `portal_type` search criteria for `contentFilter` is a list or tuple.

```
2021-11-23T11:44:36 ERROR Zope.SiteErrorLog 1637664276.570.365777764677 http://localhost:9090/senaite_storage/SF-00001/view/folderitems
Traceback (innermost last):
  Module ZServer.ZPublisher.Publish, line 144, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZServer.ZPublisher.Publish, line 44, in call_object
  Module senaite.app.listing.view, line 215, in __call__
  Module senaite.app.listing.ajax, line 109, in handle_subpath
  Module senaite.core.decorators, line 20, in decorator
  Module senaite.app.listing.decorators, line 63, in wrapper
  Module senaite.app.listing.decorators, line 50, in wrapper
  Module senaite.app.listing.decorators, line 100, in wrapper
  Module senaite.app.listing.ajax, line 432, in ajax_folderitems
  Module senaite.app.listing.decorators, line 88, in wrapper
  Module senaite.app.listing.ajax, line 313, in get_folderitems
  Module senaite.app.listing.view, line 900, in folderitems
  Module senaite.app.listing.view, line 715, in _fetch_brains
  Module senaite.app.listing.view, line 769, in search
  Module senaite.app.listing.view, line 732, in get_search_index
AttributeError: 'list' object has no attribute 'lower'
```

## Desired behavior after PR is merged

List/tuples are supported for `portal_type` criteria in `contentFilter`

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
