### PR TITLE
Improved listing search for queries containing non alphanumeric characters

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,7 @@
 2.2.0 (unreleased)
 ------------------
 
-- no changes yet
+- #64 Improved listing search for queries containing non alphanumeric characters
 
 
 2.1.0 (2022-01-05)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR improves the search results for listings

## Current behavior before PR

Search terms containing hyphens, dots or any other non alphanumeric characters returned no search results

## Desired behavior after PR is merged

Search terms containing non alphanumeric characters return partially matching search results

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
