### PR TITLE
Use searchable text index converter from catalog API

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.2.0 (unreleased)
 ------------------
 
+- #65 Use searchable text index converter from catalog API
 - #64 Improved listing search for queries containing non alphanumeric characters
 
 

--- a/src/senaite/app/listing/view.py
+++ b/src/senaite/app/listing/view.py
@@ -41,6 +41,7 @@ from senaite.app.listing.ajax import AjaxListingView
 from senaite.app.listing.interfaces import IListingView
 from senaite.app.listing.interfaces import IListingViewAdapter
 from senaite.app.supermodel import SuperModel
+from senaite.core.api.catalog import to_searchable_text_qs
 from senaite.core.catalog import ANALYSIS_CATALOG
 from senaite.core.catalog import AUDITLOG_CATALOG
 from senaite.core.catalog import SAMPLE_CATALOG
@@ -656,15 +657,6 @@ class ListingView(AjaxListingView):
         key = "{}_filter".format(form_id)
         return self.request.form.get(key, "")
 
-    def to_searchterm(self, q):
-        """generate a wildcard searchterm
-        """
-        term = api.safe_unicode(q)
-        tokens = re.split(r"[^\w]", term, flags=re.U | re.I)
-        tokens = filter(None, tokens)
-        tokens = map(lambda t: t + "*", tokens)
-        return " AND ".join(tokens)
-
     def metadata_search(self, catalog, query, searchterm, ignorecase=True):
         """ Retrieves all the brains from given catalog and returns the ones
         with at least one metadata containing the search term
@@ -763,7 +755,7 @@ class ListingView(AjaxListingView):
         # start the timer for performance checks
         start = time.time()
 
-        searchterm = self.to_searchterm(searchterm)
+        searchterm = to_searchable_text_qs(searchterm)
         logger.info(u"ListingView::search:searchterm='{}'".format(searchterm))
 
         # create a catalog query


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR uses the searchable text converter from `senaite.core.api.catalog` to build a proper query string in listings

## Current behavior before PR

query strings converted by local method

## Desired behavior after PR is merged

query string built by `senaite.core.api.catalog` API

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
