### PR TITLE
Allow to hook listings with Ajax edit form adapters

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.2.0 (unreleased)
 ------------------
 
+- #67 Allow to hook listings with Ajax edit form adapters
 - #66 Change datetime component to separate date and time fields
 - #65 Use searchable text index converter from catalog API
 - #64 Improved listing search for queries containing non alphanumeric characters

--- a/src/senaite/app/listing/templates/contents_table.pt
+++ b/src/senaite/app/listing/templates/contents_table.pt
@@ -6,14 +6,22 @@
         method="post"
         i18n:domain="senaite.core"
         tal:omit-tag="view/omit_form"
+        tal:define="form_adapter_name view/form_adapter_name|nothing;
+                    ajax_form_class python:'senaite-ajax-form' if form_adapter_name else '';
+                    additional_form_class python:view.additional_form_class"
         tal:attributes="id python:view.form_id;
+                        class string:form form-inline ${ajax_form_class} ${additional_form_class};
                         action python:view.getPOSTAction()">
 
-    <input tal:condition="not: view/omit_form"
-           tal:replace="structure context/@@authenticator/authenticator"/>
+    <tal:has-form condition="not:view/omit_form">
+      <input tal:replace="structure context/@@authenticator/authenticator"/>
 
-    <input tal:condition="not: view/omit_form"
-           type="hidden" name="submitted" value="1"/>
+      <input type="hidden" name="submitted" value="1"/>
+
+      <input tal:condition="form_adapter_name"
+             type="hidden" name="form_adapter_name" value=""
+             tal:attributes="value form_adapter_name" />
+    </tal:has-form>
 
     <!-- ReactJS managed component -->
     <div class="ajax-contents-table w-100"

--- a/src/senaite/app/listing/view.py
+++ b/src/senaite/app/listing/view.py
@@ -113,6 +113,13 @@ class ListingView(AjaxListingView):
     # form_id must be unique for each listing table.
     form_id = "list"
 
+    # CSS classes to append to the listing form
+    additional_form_class = ""
+
+    # Form adapter name that is called when the values are edited.
+    # see: `senaite.core.browser.form.adapters` for examples.
+    form_adapter_name = ""
+
     # This is an override and a switch, but it does not guarantee allow_edit.
     # This can be used to turn it off, regardless of settings in place by
     # individual items/fields, but if it is turned on, ultimate control


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR allows to set the following attributes to listing views:

```python
# CSS classes to append to the listing form
additional_form_class = ""

# Form adapter name that is called when the values are edited.
# see: `senaite.core.browser.form.adapters` for examples.
form_adapter_name = ""
```
This allows the listing form to be hooked by an edit form adapter introduced in https://github.com/senaite/senaite.core/pull/1719

## Current behavior before PR

Listing forms could not be hooked to edit form adapters

## Desired behavior after PR is merged

By specifying `form_adapter_name` to a listing view, one can register an edit form adapter like this, e.g. for `form_adapter_name=lab_analyses_results_form`:

```xml
  <!-- Listing Form: Lab Analyses -->
  <adapter
      name="lab_analyses_results_form"
      for="bika.lims.interfaces.IAnalysisRequest
           zope.publisher.interfaces.browser.IBrowserRequest"
      factory=".sample.LabAnalysesResultsForm"/>
```

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
