### PR TITLE
Reduce logging

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,7 @@
 2.3.0 (unreleased)
 ------------------
 
-- no changes yet
+- #75 Reduce logging
 
 
 2.2.0 (2022-06-10)

--- a/src/senaite/app/listing/view.py
+++ b/src/senaite/app/listing/view.py
@@ -208,7 +208,7 @@ class ListingView(AjaxListingView):
     def __call__(self):
         """Handle request parameters and render the form
         """
-        logger.info(u"ListingView::__call__")
+        logger.debug(u"ListingView::__call__")
 
         self.portal = api.get_portal()
         self.mtool = api.get_tool("portal_membership")
@@ -231,14 +231,14 @@ class ListingView(AjaxListingView):
     def update(self):
         """Update the view state
         """
-        logger.info(u"ListingView::update")
+        logger.debug(u"ListingView::update")
         self.limit_from = self.get_limit_from()
         self.pagesize = self.get_pagesize()
 
     def before_render(self):
         """Before render hook
         """
-        logger.info(u"ListingView::before_render")
+        logger.debug(u"ListingView::before_render")
         for subscriber in self.get_listing_view_adapters():
             logger.info(u"ListingView::before_render::{}.{}".format(
                 subscriber.__module__, subscriber.__class__.__name__))
@@ -410,7 +410,7 @@ class ListingView(AjaxListingView):
         state_title = wf.getTitleForStateOnType(state, portal_type)
         translated_state = ts.translate(
             _(state_title or state), context=self.request)
-        logger.info(u"ListingView:translate_review_state: {} -> {} -> {}"
+        logger.debug(u"ListingView:translate_review_state: {} -> {} -> {}"
                     .format(state, state_title, translated_state))
         return translated_state
 
@@ -764,7 +764,7 @@ class ListingView(AjaxListingView):
         start = time.time()
 
         searchterm = to_searchable_text_qs(searchterm)
-        logger.info(u"ListingView::search:searchterm='{}'".format(searchterm))
+        logger.debug(u"ListingView::search:searchterm='{}'".format(searchterm))
 
         # create a catalog query
         logger.info(u"ListingView::search: Prepare catalog query for '{}'"


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the logging facility for some messages to `debug`

## Current behavior before PR

Very verbose logging

## Desired behavior after PR is merged

Less verbose logging

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
