### PR TITLE
Fix items count in pagination when items are filtered programmatically

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.3.0 (unreleased)
 ------------------
 
+- #77 Fix items count in pagination when items are filtered programmatically
 - #76 Fix multiselect allows duplicates when ResultValue is not a string
 - #75 Reduce logging
 

--- a/src/senaite/app/listing/view.py
+++ b/src/senaite/app/listing/view.py
@@ -793,6 +793,9 @@ class ListingView(AjaxListingView):
             brains = self.metadata_search(
                 catalog, query, searchterm, ignorecase)
 
+        # Filter manually?
+        brains = filter(lambda brain: self.isItemAllowed(brain), brains)
+
         # Sort manually?
         if self.manual_sort_on:
             brains = self.sort_brains(brains, sort_on=self.manual_sort_on)
@@ -914,11 +917,6 @@ class ListingView(AjaxListingView):
                 # Maximum number of items to be shown reached!
                 self.show_more = True
                 break
-
-            # check if the item must be rendered
-            if not obj or not self.isItemAllowed(obj):
-                self.total -= 1  # correct the total number of results
-                continue
 
             # create a new folderitem
             item = self.make_empty_folderitem(**self.get_item_info(obj))


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request fixes the pagination counter for when the items of the listing are filtered programmatically by means of `isItemAllowed` function, e.g. https://github.com/senaite/senaite.core/pull/2029

## Current behavior before PR

Wrong items count in pagination when items are filtered by means of `isItemAllowed`

![Captura de 2022-06-30 13-28-23](https://user-images.githubusercontent.com/832627/176667923-ae5092cc-834f-4fd1-b717-3716384c64f8.png)


## Desired behavior after PR is merged

Correct items count in pagination when items are filtered by means of `isItemAllowed`

![Captura de 2022-06-30 13-32-08](https://user-images.githubusercontent.com/832627/176667939-d5d3f650-cbad-4612-88e1-2eae8fd771b7.png)


--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
