### PR TITLE
Fix items count when items are filtered programmatically (#77 port)

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.5.4 (unreleased)
 ------------------
 
+- #78 Fix items count when items are filtered programmatically (#77 port)
 - #61 Make ajax functions to use readonly transactions (ports #49 and #54)
 
 1.5.3 (2021-07-24)

--- a/src/senaite/core/listing/view.py
+++ b/src/senaite/core/listing/view.py
@@ -767,6 +767,9 @@ class ListingView(AjaxListingView):
             brains = self.metadata_search(
                 catalog, query, searchterm, ignorecase)
 
+        # Filter manually?
+        brains = filter(lambda brain: self.isItemAllowed(brain), brains)
+
         # Sort manually?
         if self.manual_sort_on:
             brains = self.sort_brains(brains, sort_on=self.manual_sort_on)
@@ -854,10 +857,6 @@ class ListingView(AjaxListingView):
                 # Maximum number of items to be shown reached!
                 self.show_more = True
                 break
-
-            # check if the item must be rendered
-            if not obj or not self.isItemAllowed(obj):
-                continue
 
             # Building the dictionary with basic items
             item = {


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ports #77 to 1.x

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
