### PR TITLE
Avoid duplicate listing form names

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.3.0 (unreleased)
 ------------------
 
+- #79 Avoid duplicate listing form names
 - #77 Fix items count in pagination when items are filtered programmatically
 - #76 Fix multiselect allows duplicates when ResultValue is not a string
 - #75 Reduce logging

--- a/src/senaite/app/listing/ajax.py
+++ b/src/senaite/app/listing/ajax.py
@@ -337,6 +337,7 @@ class AjaxListingView(BrowserView):
 
         config = {
             "form_id": self.form_id,
+            "form_name": self.get_form_name(),
             "review_states": self.get_review_states(),
             "columns": self.get_columns(),
             "content_filter": self.contentFilter,

--- a/src/senaite/app/listing/templates/contents_table.pt
+++ b/src/senaite/app/listing/templates/contents_table.pt
@@ -2,7 +2,7 @@
   define="portal context/@@plone_portal_state/portal;">
 
   <form name="listing_form"
-        class="form form-inline"
+        class="listing_form form form-inline"
         method="post"
         i18n:domain="senaite.core"
         tal:omit-tag="view/omit_form"
@@ -10,6 +10,7 @@
                     ajax_form_class python:'senaite-ajax-form' if form_adapter_name else '';
                     additional_form_class python:view.additional_form_class"
         tal:attributes="id python:view.form_id;
+                        name python:view.get_form_name();
                         class string:form form-inline ${ajax_form_class} ${additional_form_class};
                         action python:view.getPOSTAction()">
 

--- a/src/senaite/app/listing/view.py
+++ b/src/senaite/app/listing/view.py
@@ -114,6 +114,9 @@ class ListingView(AjaxListingView):
     # form_id must be unique for each listing table.
     form_id = "list"
 
+    # Allow manual override with this value, otherwise form_id is used
+    form_name = None
+
     # CSS classes to append to the listing form
     additional_form_class = ""
 
@@ -243,6 +246,18 @@ class ListingView(AjaxListingView):
             logger.info(u"ListingView::before_render::{}.{}".format(
                 subscriber.__module__, subscriber.__class__.__name__))
             subscriber.before_render()
+
+    def get_form_name(self):
+        """Return the name of the form
+
+        NOTE: it must be unique when multiple forms are used, otherwise the
+              values will be combined in the request!
+
+        :returns: The `form_name` attribute of the `form_id` attribute
+        """
+        if self.form_name is None:
+            return self.form_id
+        return self.form_name
 
     @property
     @view.memoize


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the `form[name]` attribute of the listing tables to be the same as the `form_id`. If needed, it can be customized with the `form_name` attribute of the view.

Related core ticket: https://github.com/senaite/senaite.core/pull/2082

## Current behavior before PR

Form name is always `listing_form`, which causes duplicate request keys if multiple forms are rendered on one page

## Desired behavior after PR is merged

Form name is per default set to the `form_id` attribute, but can be customized via the `form_name` attribute

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
