### PR TITLE
Allow additional hidden fields in listing form

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.3.0 (unreleased)
 ------------------
 
+- #79 Avoid duplicate listing form names
 - #77 Fix items count in pagination when items are filtered programmatically
 - #76 Fix multiselect allows duplicates when ResultValue is not a string
 - #75 Reduce logging

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.3.0 (unreleased)
 ------------------
 
+- #80 Allow additional hidden fields in listing form
 - #79 Avoid duplicate listing form names
 - #77 Fix items count in pagination when items are filtered programmatically
 - #76 Fix multiselect allows duplicates when ResultValue is not a string

--- a/src/senaite/app/listing/ajax.py
+++ b/src/senaite/app/listing/ajax.py
@@ -337,6 +337,7 @@ class AjaxListingView(BrowserView):
 
         config = {
             "form_id": self.form_id,
+            "form_name": self.get_form_name(),
             "review_states": self.get_review_states(),
             "columns": self.get_columns(),
             "content_filter": self.contentFilter,

--- a/src/senaite/app/listing/templates/contents_table.pt
+++ b/src/senaite/app/listing/templates/contents_table.pt
@@ -22,6 +22,13 @@
       <input tal:condition="form_adapter_name"
              type="hidden" name="form_adapter_name" value=""
              tal:attributes="value form_adapter_name" />
+
+      <!-- additional hidden fields -->
+      <input
+        type="hidden"
+        tal:repeat="input_attrs python:view.additional_hidden_fields"
+        tal:attributes="python:input_attrs"/>
+
     </tal:has-form>
 
     <!-- ReactJS managed component -->

--- a/src/senaite/app/listing/templates/contents_table.pt
+++ b/src/senaite/app/listing/templates/contents_table.pt
@@ -2,7 +2,7 @@
   define="portal context/@@plone_portal_state/portal;">
 
   <form name="listing_form"
-        class="form form-inline"
+        class="listing_form form form-inline"
         method="post"
         i18n:domain="senaite.core"
         tal:omit-tag="view/omit_form"
@@ -10,6 +10,7 @@
                     ajax_form_class python:'senaite-ajax-form' if form_adapter_name else '';
                     additional_form_class python:view.additional_form_class"
         tal:attributes="id python:view.form_id;
+                        name python:view.get_form_name();
                         class string:form form-inline ${ajax_form_class} ${additional_form_class};
                         action python:view.getPOSTAction()">
 

--- a/src/senaite/app/listing/view.py
+++ b/src/senaite/app/listing/view.py
@@ -114,6 +114,9 @@ class ListingView(AjaxListingView):
     # form_id must be unique for each listing table.
     form_id = "list"
 
+    # Allow manual override with this value, otherwise form_id is used
+    form_name = None
+
     # CSS classes to append to the listing form
     additional_form_class = ""
 
@@ -243,6 +246,18 @@ class ListingView(AjaxListingView):
             logger.info(u"ListingView::before_render::{}.{}".format(
                 subscriber.__module__, subscriber.__class__.__name__))
             subscriber.before_render()
+
+    def get_form_name(self):
+        """Return the name of the form
+
+        NOTE: it must be unique when multiple forms are used, otherwise the
+              values will be combined in the request!
+
+        :returns: The `form_name` attribute of the `form_id` attribute
+        """
+        if self.form_name is None:
+            return self.form_id
+        return self.form_name
 
     @property
     @view.memoize

--- a/src/senaite/app/listing/view.py
+++ b/src/senaite/app/listing/view.py
@@ -120,6 +120,12 @@ class ListingView(AjaxListingView):
     # CSS classes to append to the listing form
     additional_form_class = ""
 
+    # List of dictionaries containing attributes for additional hidden fields.
+    # The keys `name` and `value` must be present, but may also contain other
+    # valid HTML attributes for input fields.
+    # Example: [{"name": "my_parameter", "value": "my_value"}]
+    additional_hidden_fields = []
+
     # Form adapter name that is called when the values are edited.
     # see: `senaite.core.browser.form.adapters` for examples.
     form_adapter_name = ""


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

**Please merge https://github.com/senaite/senaite.app.listing/pull/79 first**

This PR introduces a new view attribute called `additional_hidden_fields` to inject additional hidden fields in the listing table.

The notation is a list of dictionaries, containing only the attributes of the additional hidden fields. Mandatory keys are `name` and `value`, but in fact even the `type` or other allowed HTML attributes can be set

## Current behavior before PR

Not possible to add additional hidden fields

## Desired behavior after PR is merged

Possible to inject additional hidden fields in the listing

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
