### PR TITLE
No Ajax transitions for add_analyses/manage_analyses views

### DIFF
--- a/src/senaite/app/listing/controlpanel.py
+++ b/src/senaite/app/listing/controlpanel.py
@@ -42,7 +42,8 @@ class IListingRegistry(ISenaiteRegistry):
             "WorksheetFolder",  # delete action not working in Ajax mode
             "published_results",  # download action not working in Ajax mode
             "reports_listing",  # download action not working in Ajax mode
-            "add_analyses",  # better to reload WS assign analyses
+            "add_analyses",  # reload after assigning analyses in worksheets
+            "manage_analyses",  # reload after adding analyses in samples
         ],
         required=False,
     )

--- a/src/senaite/app/listing/controlpanel.py
+++ b/src/senaite/app/listing/controlpanel.py
@@ -42,6 +42,7 @@ class IListingRegistry(ISenaiteRegistry):
             "WorksheetFolder",  # delete action not working in Ajax mode
             "published_results",  # download action not working in Ajax mode
             "reports_listing",  # download action not working in Ajax mode
+            "add_analyses",  # better to reload WS assign analyses
         ],
         required=False,
     )

--- a/src/senaite/app/listing/controlpanel.py
+++ b/src/senaite/app/listing/controlpanel.py
@@ -43,7 +43,7 @@ class IListingRegistry(ISenaiteRegistry):
             "published_results",  # download action not working in Ajax mode
             "reports_listing",  # download action not working in Ajax mode
             "add_analyses",  # reload after assigning analyses in worksheets
-            "manage_analyses",  # reload after adding analyses in samples
+            "analyses",  # reload after adding analyses in samples
         ],
         required=False,
     )


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This is a complementary PR for https://github.com/senaite/senaite.app.listing/pull/87

## Current behavior before PR

WS `add_analyses` view remain on the same view after analyses have been assigned

## Desired behavior after PR is merged

WS `add_analyses` view always performs a full page reload to jump directly to the selected layout (probably more user-friendly)

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
