### PR TITLE
Add workflow state of view context to listing config

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.3.0 (unreleased)
 ------------------
 
+- #92 Add workflow state of view context to listing config
 - #87 Add support to submit transitions via Ajax
 - #86 Do not inject unit implicitly for fields
 - #85 Support to refetch all folderitems on save

--- a/src/senaite/app/listing/ajax.py
+++ b/src/senaite/app/listing/ajax.py
@@ -388,6 +388,7 @@ class AjaxListingView(BrowserView):
             "sortable_columns": self.get_sortable_columns(),
             "show_search": self.show_search,
             "fetch_transitions_on_select": self.fetch_transitions_on_select,
+            "view_context_state": api.get_workflow_status_of(self.context),
         }
 
         return config


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR adds the workflow state of the current view context to the configuration data

## Current behavior before PR

Workflow state of listing view context not present 

## Desired behavior after PR is merged

Workflow state of listing view context present
--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
