### PR TITLE
Fix action buttons are displayed for items without allowed transitions

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,7 @@
 2.4.0 (unreleased)
 ------------------
 
-- no changes yet
+- #94 Fix action buttons are displayed for items without allowed transitions
 
 
 2.3.0 (2022-10-03)

--- a/src/senaite/app/listing/ajax.py
+++ b/src/senaite/app/listing/ajax.py
@@ -222,9 +222,11 @@ class AjaxListingView(BrowserView):
             # TODO: Research how to avoid the object wakeup here
             obj = api.get_object_by_uid(uid)
             obj_transitions = self.get_transitions_for(obj)
-            # skip objects w/o transitions, e.g. retracted/rejected analyses
             if not obj_transitions:
-                continue
+                # no need to go any further, no shared transitions can exist
+                common_tids.clear()
+                break
+
             tids = []
             for transition in obj_transitions:
                 tid = transition.get("id")

--- a/src/senaite/app/listing/ajax.py
+++ b/src/senaite/app/listing/ajax.py
@@ -224,7 +224,10 @@ class AjaxListingView(BrowserView):
             obj = api.get_object_by_uid(uid)
             obj_transitions = self.get_transitions_for(obj)
             if not obj_transitions:
-                # skip retracted/rejected analyses
+                # skip retracted/rejected analyses because we do want users to
+                # be able to do transitions to selected analyses in worksheet
+                # context even when rejected and retracted are selected. This
+                # makes the worksheet more usable and reduces frustration
                 if api.get_review_status(obj) in ["rejected", "retracted"]:
                     continue
                 # no need to go any further, no shared transitions can exist

--- a/src/senaite/app/listing/ajax.py
+++ b/src/senaite/app/listing/ajax.py
@@ -218,11 +218,15 @@ class AjaxListingView(BrowserView):
         # transition ids all objects have in common
         common_tids = set()
 
+        # statuses to skip when no transitions are found
         for uid in uids:
             # TODO: Research how to avoid the object wakeup here
             obj = api.get_object_by_uid(uid)
             obj_transitions = self.get_transitions_for(obj)
             if not obj_transitions:
+                # skip retracted/rejected analyses
+                if api.get_review_status(obj) in ["rejected", "retracted"]:
+                    continue
                 # no need to go any further, no shared transitions can exist
                 common_tids.clear()
                 break


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request makes the system to behave correctly when multiple items from a listing are selected and one or some of them (but not all) do not have allowed transitions. At the moment, the system omits these "empty" items and display the action buttons below the list with the transitions the rest of selected items have in common.

## Current behavior before PR

When multiple items are selected and some of them, but not all, do not have any transition allowed, system skips them and displays the action buttons with the transitions that the rest of selected items have in common.

## Desired behavior after PR is merged

When multiple items are selected and some of them, but not all, do not have any transition allowed, system does not skip them and does not display any action button.

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
