### PR TITLE
Fix cannot sort when the query of the listing contains UID

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.4.0 (unreleased)
 ------------------
 
+- #95 Fix cannot sort when the query of the listing contains UID
 - #94 Fix action buttons are displayed for items without allowed transitions
 
 

--- a/src/senaite/app/listing/view.py
+++ b/src/senaite/app/listing/view.py
@@ -596,12 +596,10 @@ class ListingView(AjaxListingView):
         # Skip all further processing if explicit UIDs are requested.
         # This is required to render child-nodes properly.
         # https://github.com/senaite/senaite.app.listing/issues/12
-        if "UID" in query:
-            return query
-
-        # contentFilter is allowed in every self.review_state.
-        for k, v in self.review_state.get("contentFilter", {}).items():
-            query[k] = v
+        if "UID" not in query:
+            # contentFilter is allowed in every self.review_state.
+            for k, v in self.review_state.get("contentFilter", {}).items():
+                query[k] = v
 
         sort_on = self.get_sort_on()
         # check if the sort_on criteria is a valid search index


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ensures that sorting functionality works even if the query used for the listing contains "UID" as an index. 

## Current behavior before PR

Listings made of a query containing "UID" as an index cannot be sorted

## Desired behavior after PR is merged

Listings made of a query containing "UID" as an index can be sorted

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
