### PR TITLE
Fix cannot sort when the query of the listing contains UID (#95 port)

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 1.5.4 (unreleased)
 ------------------
 
+- #96 Fix cannot sort when the query of the listing contains UID (#95 port)
 - #83 Allow custom confirmation messages for transitions (#82 port)
 - #78 Fix items count when items are filtered programmatically (#77 port)
 - #61 Make ajax functions to use readonly transactions (ports #49 and #54)

--- a/src/senaite/core/listing/view.py
+++ b/src/senaite/core/listing/view.py
@@ -562,12 +562,10 @@ class ListingView(AjaxListingView):
         # Skip all further processing if explicit UIDs are requested.
         # This is required to render child-nodes properly.
         # https://github.com/senaite/senaite.core.listing/issues/12
-        if "UID" in query:
-            return query
-
-        # contentFilter is allowed in every self.review_state.
-        for k, v in self.review_state.get("contentFilter", {}).items():
-            query[k] = v
+        if "UID" not in query:
+            # contentFilter is allowed in every self.review_state.
+            for k, v in self.review_state.get("contentFilter", {}).items():
+                query[k] = v
 
         sort_on = self.get_sort_on()
         # check if the sort_on criteria is a valid search index


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This Pull Request ports https://github.com/senaite/senaite.app.listing/pull/95 to v1.x

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
