### PR TITLE
Handle transition fails without UI notification

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.5.0 (unreleased)
 ------------------
 
+- #112 Handle transition fails without UI notification
 - #110 Sequential save action
 - #109 Allow to set the size of input fields from inside cells
 - #108 Sequential Ajax Transitions


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR avoids propagation of transition fails back to the UI, because it is in most cases an expected side-effect if e.g. Analyses with calculations are submitted and dependent analyses get submitted automatically

## Current behavior before PR

Error message is displayed in the UI if e.g. an dependent analysis is submitted *after* it was already submitted by a previous analysis due to calculation dependency.

## Desired behavior after PR is merged

Warning message is logged

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
