### PR TITLE
Enable ajax transitions per default

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.5.0 (unreleased)
 ------------------
 
+- #113 Enable ajax transitions per default
 - #110 Sequential save action
 - #109 Allow to set the size of input fields from inside cells
 - #108 Sequential Ajax Transitions

--- a/src/senaite/app/listing/controlpanel.py
+++ b/src/senaite/app/listing/controlpanel.py
@@ -41,7 +41,7 @@ class IListingRegistry(ISenaiteRegistry):
     listing_enable_ajax_transitions = schema.Bool(
         title=_("Enable Ajax Transitions"),
         description=_("Enable sequential ajax workflow transitions"),
-        default=False,
+        default=True,
         required=False,
     )
 
@@ -50,13 +50,13 @@ class IListingRegistry(ISenaiteRegistry):
         description=_("Transitions that are processed sequentially via ajax"),
         value_type=schema.ASCIILine(),
         default=[
+            "activate",
+            "cancel",
+            "deactivate",
             "receive",
+            "reinstate",
             "submit",
             "verify",
-            "cancel",
-            "reinstate",
-            "deactivate",
-            "activate",
         ],
         required=False,
     )


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR enables Ajax Transitions per default

## Current behavior before PR

Ajax transitions disabled per default

## Desired behavior after PR is merged

Ajax transitions enabled per default

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
