### PR TITLE
Compatibility with senaite.core i18n

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.5.0 (unreleased)
 ------------------
 
+- #117 Compatibility with senaite.core i18n
 - #116 Fix datetime value is not updated onchange
 - #115 Support redirects after Ajax transitions
 - #114 Fix Ajax Transitions for Transposed Worksheet Layout

--- a/src/senaite/app/listing/decorators.py
+++ b/src/senaite/app/listing/decorators.py
@@ -22,11 +22,11 @@ import json
 import time
 from functools import wraps
 
-from bika.lims import logger
-from bika.lims.utils import t
-from zope.i18nmessageid import Message
-from DateTime import DateTime
 from bika.lims import api
+from bika.lims import logger
+from DateTime import DateTime
+from senaite.core.i18n import translate as t
+from zope.i18nmessageid import Message
 
 
 def returns_safe_json(func):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR provides compatibility for https://github.com/senaite/senaite.core/pull/2389

## Current behavior before PR

Import `from bika.lims.utils import t` is used

## Desired behavior after PR is merged

Import `from senaite.core.i18n import translate as t` is used

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
