### PR TITLE
Fix APIError for non-UID listings

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.5.0 (unreleased)
 ------------------
 
+- #134 Fix APIError for non-UID listings
 - #133 Multiselect with duplicates support for interim fields
 - #132 Improve transposed interims formatting
 - #131 Added FractionField for fraction-like results support

--- a/src/senaite/app/listing/adapters/transitions.py
+++ b/src/senaite/app/listing/adapters/transitions.py
@@ -129,6 +129,8 @@ class ListingTransitions(object):
 
         for uid in uids:
             obj = self.get_object_by_uid(uid)
+            if obj is None:
+                continue
             transitions = api.get_transitions_for(obj)
             if not transitions:
                 review_state = api.get_review_status(obj)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes an `APIError` for listings where the UID does not refer to an object.

## Current behavior before PR

Traceback occurs:

```
  Module ZPublisher.WSGIPublisher, line 176, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 385, in publish_module
  Module ZPublisher.WSGIPublisher, line 288, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 63, in call_object
  Module senaite.app.listing.view, line 248, in __call__
  Module senaite.app.listing.ajax, line 113, in handle_subpath
  Module senaite.core.decorators, line 40, in decorator
  Module senaite.app.listing.decorators, line 63, in wrapper
  Module senaite.app.listing.decorators, line 50, in wrapper
  Module senaite.app.listing.decorators, line 100, in wrapper
  Module senaite.app.listing.ajax, line 447, in ajax_transitions
  Module senaite.app.listing.ajax, line 201, in get_allowed_transitions_for
  Module senaite.app.listing.adapters.transitions, line 90, in get_transitions
  Module wasserbw.lims.adapter.transitions, line 69, in get_workflow_transitions
  Module senaite.app.listing.adapters.transitions, line 132, in get_workflow_transitions
  Module bika.lims.api, line 1166, in get_transitions_for
  Module bika.lims.api, line 381, in get_object
  Module bika.lims.api, line 344, in fail
APIError: None is not supported.
```

## Desired behavior after PR is merged

Non object UIDs are skipped

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
