### PR TITLE
Fix non-UID keyed folder items can not be pre-selected by the server

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.5.0 (unreleased)
 ------------------
 
+- #135 Fix non-UID keyed folder items can not be pre-selected by the server
 - #134 Fix APIError for non-UID listings
 - #133 Multiselect with duplicates support for interim fields
 - #132 Improve transposed interims formatting

--- a/src/senaite/app/listing/ajax.py
+++ b/src/senaite/app/listing/ajax.py
@@ -385,7 +385,6 @@ class AjaxListingView(BrowserView):
         # Process selected UIDs and their allowed transitions
         uids_to_keep = payload.get("selected_uids")
         selected_uids = self.get_selected_uids(folderitems, uids_to_keep)
-        selected_uids = filter(api.is_uid, selected_uids)
         transitions = self.get_allowed_transitions_for(selected_uids)
 
         # get the view config


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR is related to https://github.com/senaite/senaite.app.listing/pull/134 and allows non-uid keyed folderitems to be pre-selected by the server.

## Current behavior before PR

Items that have a non-object UID, e.g. an index, can not be preselected.

## Desired behavior after PR is merged

Items that have a non-object UID, e.g. an index, can be preselected.

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
