### PR TITLE
Fix object reindexing in workflow transition adapter

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.5.0 (unreleased)
 ------------------
 
+- #138 Fix object reindexing in workflow transition adapter
 - #137 Support default values for multi-choices type
 - #135 Fix non-UID keyed folder items can not be pre-selected by the server
 - #134 Fix APIError for non-UID listings

--- a/src/senaite/app/listing/adapters/workflow.py
+++ b/src/senaite/app/listing/adapters/workflow.py
@@ -50,11 +50,6 @@ class ListingWorkflowTransition(object):
         oid = api.get_id(obj)
 
         try:
-            # NOTE: We need to call `doActionFor` to ensure the reindexing
-            # happens *before* the Before- and AfterTransitionEventHandlers are
-            # called.
-            # This fixes e.g. that the sample progress bar is updated correctly
-            #
             # obj = api.do_transition_for(obj, transition)
             # obj.reindexObject()
             succeed, message = doActionFor(obj, transition)

--- a/src/senaite/app/listing/adapters/workflow.py
+++ b/src/senaite/app/listing/adapters/workflow.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from bika.lims import api
+from bika.lims.workflow import doActionFor
+from Products.CMFCore.WorkflowCore import WorkflowException
 from senaite.app.listing import logger
 from senaite.app.listing import senaiteMessageFactory as _
 from senaite.app.listing.interfaces import IListingWorkflowTransition
@@ -48,12 +50,21 @@ class ListingWorkflowTransition(object):
         oid = api.get_id(obj)
 
         try:
-            obj = api.do_transition_for(obj, transition)
+            # NOTE: We need to call `doActionFor` to ensure the reindexing
+            # happens *before* the Before- and AfterTransitionEventHandlers are
+            # called.
+            # This fixes e.g. that the sample progress bar is updated correctly
+            #
+            # obj = api.do_transition_for(obj, transition)
+            # obj.reindexObject()
+            succeed, message = doActionFor(obj, transition)
+            if not succeed:
+                raise WorkflowException(message)
         except ConflictError:
             self.error["message"] = _(
                 "A database conflict error occurred during transition "
                 "'{}' on '{}'. Please try again.".format(transition, oid))
-        except api.APIError as exc:
+        except (api.APIError, WorkflowException) as exc:
             # NOTE: We do not propagate back to the UI when the transition
             #       failed, because it is most of the time an expected
             #       side-effect. E.g. when an analysis with calculation

--- a/src/senaite/app/listing/adapters/workflow.py
+++ b/src/senaite/app/listing/adapters/workflow.py
@@ -50,6 +50,7 @@ class ListingWorkflowTransition(object):
         oid = api.get_id(obj)
 
         try:
+            # https://github.com/senaite/senaite.app.listing/pull/138
             # obj = api.do_transition_for(obj, transition)
             # obj.reindexObject()
             succeed, message = doActionFor(obj, transition)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR changes the `IListingWorkflowTransition` adapter to call `bika.lims.workflow.doActionFor` instead of `bika.lims.api.do_transition_for` to ensure proper reindexing takes place.

## Current behavior before PR

Sample progress in listing is not updated when analyses are transitioned

## Desired behavior after PR is merged

Sample progress in listing is updated correctly after analyses are transitioned.

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
