### PR TITLE
Fix column sorting indicator is not initially displayed

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,7 @@
 2.6.0 (unreleased)
 ------------------
 
-- no changes yet
+- #139 Fix column sorting indicator is not initially displayed
 
 
 2.5.0 (2024-01-03)

--- a/src/senaite/app/listing/view.py
+++ b/src/senaite/app/listing/view.py
@@ -219,8 +219,6 @@ class ListingView(AjaxListingView):
         self.total = 0
         self.limit_from = 0
         self.show_more = False
-        self.sort_on = "sortable_title"
-        self.sort_order = "ascending"
 
         # Internal cache for translated state titles
         self.state_titles = {}

--- a/src/senaite/app/listing/view.py
+++ b/src/senaite/app/listing/view.py
@@ -508,8 +508,11 @@ class ListingView(AjaxListingView):
         form_id = self.get_form_id()
         key = "{}_sort_on".format(form_id)
 
-        # The sort_on parameter from the request
-        return self.request.form.get(key, None)
+        # get the sort_on value either from the form (if manually changed) or
+        # from the initial catalog query
+        form_sort_on = self.request.form.get(key)
+        query_sort_on = self.contentFilter.get("sort_on")
+        return form_sort_on or query_sort_on
 
     def is_valid_sort_index(self, sort_on):
         """Checks if the sort_on index is capable for a sort_


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR fixes the missing column sort indicator when listings are initially rendered.

## Current behavior before PR

Initial column sorting is controlled by the catalog query `sort_on` index, but the indicator is not displayed for this column in the listing.

## Desired behavior after PR is merged

Column sorting indicator is displayed in the listing according to the `sort_on` index of the catalog query.

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
