### PR TITLE
Fix 2 snapshots created for DX contents on "Save"

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.7.0 (unreleased)
 ------------------
 
+- #158 Fix 2 snapshots created for DX contents on "Save"
 - #156 Update ReactJS 18 -> 19
 - #155 Show modal and context menu loaders
 - #154 Change namespace for listings

--- a/src/senaite/app/listing/ajax.py
+++ b/src/senaite/app/listing/ajax.py
@@ -45,7 +45,6 @@ from zope.component import getMultiAdapter
 from zope.component import queryAdapter
 from zope.component import queryMultiAdapter
 from zope.interface import implementer
-from zope.lifecycleevent import modified
 from zope.publisher.interfaces import IPublishTraverse
 
 
@@ -344,9 +343,6 @@ class AjaxListingView(BrowserView):
 
         # reindex the objects
         map(lambda obj: obj.reindexObject(), updated_objects)
-
-        # notify that the objects were modified
-        map(modified, updated_objects)
 
         return updated_objects
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR removes the `modified` event that is fired on `set_field`.

## Current behavior before PR

2 Snapshots are created for DX contents when fields are set via the listing view.

## Desired behavior after PR is merged

Only 1 Snapshot is created for DX contents when fields are set via the listing view.

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
