### PR TITLE
Add fallback for filter index

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.7.0 (unreleased)
 ------------------
 
+- #162 Add fallback for filter index
 - #161 Add column filtering
 - #160 Fix detection limit result is flushed on edit
 - #159 Update sort_order and sort_on according to the review state contentFilter on change

--- a/src/senaite/app/listing/ajax.py
+++ b/src/senaite/app/listing/ajax.py
@@ -173,9 +173,10 @@ class AjaxListingView(BrowserView):
         catalog_indexes = catalog.indexes()
 
         for key, column in columns.items():
-            index_name = column.get("index")
+            index_name = column.get("index") or key
             if index_name and index_name in catalog_indexes:
                 index = catalog.Indexes.get(index_name)
+                column["index"] = index_name
                 column["index_type"] = index.__class__.__name__
             else:
                 column["index_type"] = None
@@ -757,7 +758,7 @@ class AjaxListingView(BrowserView):
         column = self.columns.get(column_key, {})
 
         # Get the filter index (or fall back to sort index)
-        orig_index = column.get("index")
+        orig_index = column.get("index") or column_key
         filter_index = column.get("filter_index")
 
         # Apply default mapping for common indexes like sortable_title -> title

--- a/src/senaite/app/listing/view.py
+++ b/src/senaite/app/listing/view.py
@@ -683,7 +683,7 @@ class ListingView(AjaxListingView):
 
             # Use filter_index if defined, otherwise apply default mapping,
             # otherwise fall back to index
-            orig_index = column.get("index")
+            orig_index = column.get("index") or column_key
             index_name = column.get("filter_index")
 
             # Apply default mapping for common indexes


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This PR complements the column filtering feature that was implemented in https://github.com/senaite/senaite.app.listing/pull/161

## Current behavior before PR

If no `index` is provided in a column, the column is not filterable

## Desired behavior after PR is merged

If no `index` is provided in a column, but the column name matches an existing index, that one is used.

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
