### PR TITLE
Fix UnicodeEncodeError when column filter values contain non-ASCII

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.7.0 (unreleased)
 ------------------
 
+- #170 Fix UnicodeEncodeError when column filter values contain non-ASCII
 - #169 Allow per-cell field type override and display value in HiddenField
 - #168 Refactor field props pattern
 - #167 refactor StringField to a modern ReactJS Component

--- a/src/senaite/app/listing/ajax.py
+++ b/src/senaite/app/listing/ajax.py
@@ -848,7 +848,8 @@ class AjaxListingView(BrowserView):
                     unique_vals = list(index.uniqueValues())
                     unique_vals = sorted([v for v in unique_vals
                                           if v is not None and v != ""])
-                    return [{"value": v, "title": str(v)} for v in unique_vals]
+                    return [{"value": v, "title": api.safe_unicode(v)}
+                            for v in unique_vals]
                 except NotImplementedError:
                     pass
             return []
@@ -874,7 +875,8 @@ class AjaxListingView(BrowserView):
 
         # Sort and convert to list of dicts
         sorted_values = sorted(unique_values)
-        return [{"value": v, "title": str(v)} for v in sorted_values]
+        return [{"value": v, "title": api.safe_unicode(v)}
+                for v in sorted_values]
 
     def notify_edited(self, obj):
         """Notify object edited event

--- a/src/senaite/app/listing/view.py
+++ b/src/senaite/app/listing/view.py
@@ -656,26 +656,6 @@ class ListingView(AjaxListingView):
         logger.info(u"ListingView::get_catalog_query: query={}".format(query))
         return query
 
-    def _coerce_filter_value(self, index, value):
-        """Coerce ``value`` to the same string type as the BTree keys.
-
-        Py2 BTree comparison of unicode against utf-8 bytes (or vice
-        versa) implicitly decodes the bytes side as ASCII and raises
-        UnicodeDecodeError on non-ASCII content. Sample the first key
-        of the index and convert ``value`` to match it. Falls back to
-        the original value when the index is empty or the key type is
-        not a string.
-        """
-        try:
-            sample_key = next(iter(index._index.keys()), None)
-        except Exception:
-            return value
-        if isinstance(sample_key, bytes):
-            return api.to_utf8(value, default=value)
-        if isinstance(sample_key, six.text_type):
-            return api.safe_unicode(value, default=value)
-        return value
-
     def apply_column_filters(self, query):
         """Apply column filters to the catalog query
 
@@ -693,13 +673,11 @@ class ListingView(AjaxListingView):
             if not filter_value:
                 continue
 
-            # FieldIndex/KeywordIndex keys are stored as whatever the
-            # indexer returned (often unicode). Encoding the query
-            # value to UTF-8 bytes upfront makes the catalog implicitly
-            # ascii-decode bytes against unicode keys, which raises
-            # UnicodeDecodeError on non-ASCII filter values. Keep the
-            # value as unicode here and only encode when an index type
-            # truly needs bytes (handled below).
+            # senaite.core indexers normalize string values via
+            # safe_unicode, so catalog index keys are unicode. Match
+            # that here to keep BTree comparisons type-aligned and
+            # avoid implicit ascii decodes on Py2.
+            filter_value = api.safe_unicode(filter_value)
 
             # Get the column definition
             column = self.columns.get(column_key, {})
@@ -733,9 +711,8 @@ class ListingView(AjaxListingView):
 
             # Apply filter based on index type
             if index_type in ("ZCTextIndex", "TextIndex"):
-                # Text indexes conventionally expect utf-8 bytes
-                text_value = api.to_utf8(filter_value, default=filter_value)
-                query[index_name] = "*{}*".format(text_value)
+                # Text indexes support wildcard search
+                query[index_name] = u"*{}*".format(filter_value)
             elif index_type in ("DateIndex", "DateRecurringIndex"):
                 # Date indexes expect a date value or range
                 try:
@@ -759,23 +736,18 @@ class ListingView(AjaxListingView):
                 query[index_name] = bool_value
             elif index_type == "FieldIndex":
                 # Field indexes: try exact match
-                query[index_name] = self._coerce_filter_value(
-                    index, filter_value)
+                query[index_name] = filter_value
             elif index_type == "KeywordIndex":
                 # Keyword indexes: search in list
-                query[index_name] = self._coerce_filter_value(
-                    index, filter_value)
+                query[index_name] = filter_value
             else:
                 # Default: try exact match to be safe
-                query[index_name] = self._coerce_filter_value(
-                    index, filter_value)
+                query[index_name] = filter_value
 
             logger.info(
                 u"ListingView::apply_column_filters: Applied filter "
                 u"%s=%s (index_type=%s)",
-                api.safe_unicode(index_name),
-                api.safe_unicode(filter_value),
-                api.safe_unicode(index_type))
+                index_name, filter_value, index_type)
 
         return query
 

--- a/src/senaite/app/listing/view.py
+++ b/src/senaite/app/listing/view.py
@@ -670,13 +670,10 @@ class ListingView(AjaxListingView):
             sample_key = next(iter(index._index.keys()), None)
         except Exception:
             return value
-        if isinstance(sample_key, bytes) and isinstance(value, six.text_type):
-            return value.encode("utf-8")
-        if isinstance(sample_key, six.text_type) and isinstance(value, bytes):
-            try:
-                return value.decode("utf-8")
-            except UnicodeDecodeError:
-                return value
+        if isinstance(sample_key, bytes):
+            return api.to_utf8(value, default=value)
+        if isinstance(sample_key, six.text_type):
+            return api.safe_unicode(value, default=value)
         return value
 
     def apply_column_filters(self, query):
@@ -736,11 +733,8 @@ class ListingView(AjaxListingView):
 
             # Apply filter based on index type
             if index_type in ("ZCTextIndex", "TextIndex"):
-                # Text indexes support wildcard search
-                if isinstance(filter_value, six.text_type):
-                    text_value = filter_value.encode("utf-8")
-                else:
-                    text_value = filter_value
+                # Text indexes conventionally expect utf-8 bytes
+                text_value = api.to_utf8(filter_value, default=filter_value)
                 query[index_name] = "*{}*".format(text_value)
             elif index_type in ("DateIndex", "DateRecurringIndex"):
                 # Date indexes expect a date value or range

--- a/src/senaite/app/listing/view.py
+++ b/src/senaite/app/listing/view.py
@@ -673,10 +673,13 @@ class ListingView(AjaxListingView):
             if not filter_value:
                 continue
 
-            # Ensure filter_value is properly encoded for catalog queries
-            # ZCatalog in Python 2 expects UTF-8 encoded byte strings
-            if isinstance(filter_value, six.text_type):
-                filter_value = filter_value.encode("utf-8")
+            # FieldIndex/KeywordIndex keys are stored as whatever the
+            # indexer returned (often unicode). Encoding the query
+            # value to UTF-8 bytes upfront makes the catalog implicitly
+            # ascii-decode bytes against unicode keys, which raises
+            # UnicodeDecodeError on non-ASCII filter values. Keep the
+            # value as unicode here and only encode when an index type
+            # truly needs bytes (handled below).
 
             # Get the column definition
             column = self.columns.get(column_key, {})

--- a/src/senaite/app/listing/view.py
+++ b/src/senaite/app/listing/view.py
@@ -656,6 +656,29 @@ class ListingView(AjaxListingView):
         logger.info(u"ListingView::get_catalog_query: query={}".format(query))
         return query
 
+    def _coerce_filter_value(self, index, value):
+        """Coerce ``value`` to the same string type as the BTree keys.
+
+        Py2 BTree comparison of unicode against utf-8 bytes (or vice
+        versa) implicitly decodes the bytes side as ASCII and raises
+        UnicodeDecodeError on non-ASCII content. Sample the first key
+        of the index and convert ``value`` to match it. Falls back to
+        the original value when the index is empty or the key type is
+        not a string.
+        """
+        try:
+            sample_key = next(iter(index._index.keys()), None)
+        except Exception:
+            return value
+        if isinstance(sample_key, bytes) and isinstance(value, six.text_type):
+            return value.encode("utf-8")
+        if isinstance(sample_key, six.text_type) and isinstance(value, bytes):
+            try:
+                return value.decode("utf-8")
+            except UnicodeDecodeError:
+                return value
+        return value
+
     def apply_column_filters(self, query):
         """Apply column filters to the catalog query
 
@@ -714,7 +737,11 @@ class ListingView(AjaxListingView):
             # Apply filter based on index type
             if index_type in ("ZCTextIndex", "TextIndex"):
                 # Text indexes support wildcard search
-                query[index_name] = "*{}*".format(filter_value)
+                if isinstance(filter_value, six.text_type):
+                    text_value = filter_value.encode("utf-8")
+                else:
+                    text_value = filter_value
+                query[index_name] = "*{}*".format(text_value)
             elif index_type in ("DateIndex", "DateRecurringIndex"):
                 # Date indexes expect a date value or range
                 try:
@@ -738,13 +765,16 @@ class ListingView(AjaxListingView):
                 query[index_name] = bool_value
             elif index_type == "FieldIndex":
                 # Field indexes: try exact match
-                query[index_name] = filter_value
+                query[index_name] = self._coerce_filter_value(
+                    index, filter_value)
             elif index_type == "KeywordIndex":
                 # Keyword indexes: search in list
-                query[index_name] = filter_value
+                query[index_name] = self._coerce_filter_value(
+                    index, filter_value)
             else:
                 # Default: try exact match to be safe
-                query[index_name] = filter_value
+                query[index_name] = self._coerce_filter_value(
+                    index, filter_value)
 
             logger.info(
                 u"ListingView::apply_column_filters: Applied filter "

--- a/src/senaite/app/listing/view.py
+++ b/src/senaite/app/listing/view.py
@@ -772,7 +772,10 @@ class ListingView(AjaxListingView):
 
             logger.info(
                 u"ListingView::apply_column_filters: Applied filter "
-                u"%s=%s (index_type=%s)", index_name, filter_value, index_type)
+                u"%s=%s (index_type=%s)",
+                api.safe_unicode(index_name),
+                api.safe_unicode(filter_value),
+                api.safe_unicode(index_type))
 
         return query
 


### PR DESCRIPTION
## Description of the issue / feature this PR addresses

Two related Py2 unicode bugs in the column filter path surface as soon
as a filter index contains non-ASCII values (e.g. a laboratory title
with German umlauts).

**1. UnicodeEncodeError opening the dropdown.**
`get_unique_column_values` rendered filter dropdown titles via
`str(v)`, which forces an ASCII encode of unicode index values:

```
UnicodeEncodeError: 'ascii' codec can't encode character u'\xfc'
in position 21: ordinal not in range(128)
```

**2. UnicodeDecodeError submitting the filter.**
`apply_column_filters` pre-encoded every unicode filter value to UTF-8
bytes before dispatching on index type. FieldIndex / KeywordIndex keys
are stored as whatever the indexer returned (often unicode), so
comparing UTF-8 bytes against unicode keys triggers an implicit ASCII
decode of the bytes:

```
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in
position 21: ordinal not in range(128)
```

## Current behavior before PR

Opening or submitting a column filter on any index whose values
contain non-ASCII characters 500s with the tracebacks above.

## Desired behavior after PR is merged

- Dropdown titles round-trip as unicode via `api.safe_unicode`; the
  JSON encoder downstream handles the wire encoding.
- Filter values are passed to the catalog as unicode; FieldIndex,
  KeywordIndex and ZCTextIndex all handle unicode correctly here in
  practice (Plone's CatalogTool encodes for ZCTextIndex itself).

## I have...

- [x] confirmed that this PR is following the [SENAITE styleguide](https://github.com/senaite/senaite.styleguide)
- [x] followed the [PEP8](https://peps.python.org/pep-0008/) style guide
- [x] added an entry to the Changelog