### PR TITLE
Add global "Fetch transitions on select" listing setting

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.7.0 (unreleased)
 ------------------
 
+- #173 Add global "Fetch transitions on select" listing setting
 - #171 Fix TypeError in SearchableSelect when option values are non-string
 - #170 Fix UnicodeEncodeError when column filter values contain non-ASCII
 - #169 Allow per-cell field type override and display value in HiddenField

--- a/src/senaite/app/listing/ajax.py
+++ b/src/senaite/app/listing/ajax.py
@@ -258,6 +258,19 @@ class AjaxListingView(BrowserView):
         """
         return self.show_column_toggles
 
+    def get_fetch_transitions_on_select(self):
+        """Returns whether the possible workflow transitions should be fetched
+        automatically when items get selected in the listing.
+
+        A per-listing value (`fetch_transitions_on_select` attribute) takes
+        precedence. If it is left as `None`, the global default stored in the
+        `listing_fetch_transitions_on_select` registry record is used.
+        """
+        override = getattr(self, "fetch_transitions_on_select", None)
+        if override is not None:
+            return override
+        return get_registry_record("listing_fetch_transitions_on_select", True)
+
     @view.memoize
     @returns_safe_json
     def ajax_transitions_enabled(self):
@@ -336,7 +349,7 @@ class AjaxListingView(BrowserView):
             "sort_order": self.get_sort_order(),
             "sortable_columns": self.get_sortable_columns(),
             "show_search": self.show_search,
-            "fetch_transitions_on_select": self.fetch_transitions_on_select,
+            "fetch_transitions_on_select": self.get_fetch_transitions_on_select(),
             "view_context_state": api.get_workflow_status_of(self.context),
             "allow_row_reorder": self.allow_row_reorder,
             "transposed": ITransposedListingView.providedBy(self),

--- a/src/senaite/app/listing/controlpanel.py
+++ b/src/senaite/app/listing/controlpanel.py
@@ -33,9 +33,22 @@ class IListingRegistry(ISenaiteRegistry):
         label=_(u"Listings"),
         description=_("Configuration for listings"),
         fields=[
+            "listing_fetch_transitions_on_select",
             "listing_enable_ajax_transitions",
             "listing_active_ajax_transitions",
         ],
+    )
+
+    listing_fetch_transitions_on_select = schema.Bool(
+        title=_("Fetch transitions on select"),
+        description=_(
+            "Automatically fetch the possible workflow transitions when items "
+            "get selected in listings. Disabling this can speed up listings "
+            "(especially samples with many analyses) at the cost of having to "
+            "fetch the transitions manually via the row context menu. "
+            "Individual listings can still override this default."),
+        default=True,
+        required=False,
     )
 
     listing_enable_ajax_transitions = schema.Bool(

--- a/src/senaite/app/listing/profiles/default/metadata.xml
+++ b/src/senaite/app/listing/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2710</version>
+  <version>2701</version>
 </metadata>

--- a/src/senaite/app/listing/profiles/default/metadata.xml
+++ b/src/senaite/app/listing/profiles/default/metadata.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>2700</version>
+  <version>2710</version>
 </metadata>

--- a/src/senaite/app/listing/upgrades/configure.zcml
+++ b/src/senaite/app/listing/upgrades/configure.zcml
@@ -5,6 +5,14 @@
 
   <genericsetup:upgradeStep
       title="Upgrade SENAITE APP LISTING"
+      description="Version 2.7.1: Add 'fetch transitions on select' setting"
+      source="2700"
+      destination="2710"
+      handler="senaite.app.listing.upgrades.handlers.to_2710"
+      profile="senaite.app.listing:default" />
+
+  <genericsetup:upgradeStep
+      title="Upgrade SENAITE APP LISTING"
       description="Version 2.7.0"
       source="2600"
       destination="2700"

--- a/src/senaite/app/listing/upgrades/configure.zcml
+++ b/src/senaite/app/listing/upgrades/configure.zcml
@@ -4,11 +4,14 @@
     xmlns:genericsetup="http://namespaces.zope.org/genericsetup">
 
   <genericsetup:upgradeStep
-      title="Upgrade SENAITE APP LISTING"
-      description="Version 2.7.1: Add 'fetch transitions on select' setting"
+      title="Add 'Fetch transitions on select' setting"
+      description="
+        Registers the 'listing_fetch_transitions_on_select' record in the
+        registry, a global default that controls whether listings fetch the
+        possible workflow transitions automatically when items get selected."
       source="2700"
-      destination="2710"
-      handler="senaite.app.listing.upgrades.handlers.to_2710"
+      destination="2701"
+      handler="senaite.app.listing.upgrades.handlers.to_2701"
       profile="senaite.app.listing:default" />
 
   <genericsetup:upgradeStep

--- a/src/senaite/app/listing/upgrades/handlers.py
+++ b/src/senaite/app/listing/upgrades/handlers.py
@@ -23,6 +23,21 @@ from senaite.app.listing import logger
 PROFILE_ID = "profile-senaite.app.listing:default"
 
 
+def to_2710(portal_setup):
+    """Update to version 2.7.1
+
+    Registers the new `listing_fetch_transitions_on_select` registry record.
+
+    :param portal_setup: The portal_setup tool
+    """
+
+    logger.info("Import registry for SENAITE APP LISTING ...")
+    context = portal_setup._getImportContext(PROFILE_ID)
+    portal = context.getSite()  # noqa
+    portal_setup.runImportStepFromProfile(PROFILE_ID, "plone.app.registry")
+    logger.info("Import registry for SENAITE APP LISTING [DONE]")
+
+
 def to_2700(portal_setup):
     """Update to version 2.7.0
 

--- a/src/senaite/app/listing/upgrades/handlers.py
+++ b/src/senaite/app/listing/upgrades/handlers.py
@@ -23,8 +23,8 @@ from senaite.app.listing import logger
 PROFILE_ID = "profile-senaite.app.listing:default"
 
 
-def to_2710(portal_setup):
-    """Update to version 2.7.1
+def to_2701(portal_setup):
+    """Update to version 2701
 
     Registers the new `listing_fetch_transitions_on_select` registry record.
 

--- a/src/senaite/app/listing/view.py
+++ b/src/senaite/app/listing/view.py
@@ -150,7 +150,11 @@ class ListingView(AjaxListingView):
     show_select_column = False
 
     # Automatically fetch all possible transitions for selected items.
-    fetch_transitions_on_select = True
+    # Leave as `None` to follow the global default stored in the
+    # `listing_fetch_transitions_on_select` registry record (control panel).
+    # Set explicitly to `True`/`False` to override the global default for this
+    # particular listing.
+    fetch_transitions_on_select = None
 
     # Submit transitions via ajax
     enable_ajax_transitions = None


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Adds a global, control-panel-configurable setting (listing_fetch_transitions_on_select) that controls whether listings automatically fetch the possible workflow transitions whenever items get selected.

On large deployments — samples with many analyses, or busy clusters — every selection (and every "select all") triggers an ajax round-trip that loads each selected object and evaluates every transition guard to render the workflow action buttons, which can dominate interaction time. A per-user runtime toggle already exists in the row context menu ("Disable/Enable auto fetch transitions"), but it is not persistent and cannot be set as a site-wide default. This PR makes that default configurable.

<img width="887" height="521" alt="20260603135731" src="https://github.com/user-attachments/assets/dc32b57b-90b3-445a-aab2-e2d504c1e42f" />

## Current behavior before PR

- ListingView.fetch_transitions_on_select is hard-coded to True.
- Selecting items (or "select all") always fetches the allowed transitions for the whole selection via ajax_transitions → get_allowed_transitions_for().
- The only way to suppress this is the non-persistent per-user context-menu toggle; there is no site-wide setting.

## Desired behavior after PR is merged

- New registry record listing_fetch_transitions_on_select (Bool, default True → no behavior change) under the Listings control-panel fieldset.
- Resolution order (AjaxListingView.get_fetch_transitions_on_select()): a. The listing's own fetch_transitions_on_select attribute, when explicitly True/False (per-listing override); b. otherwise the global registry record.
- ListingView.fetch_transitions_on_select default changed True → None ("follow the global setting"); listings can still force the behavior by setting it explicitly.
- When disabled, action buttons are populated on demand via the existing context-menu "Fetch Transitions" entry.
- No front-end rebuild required — the React layer already supports fetch_transitions_on_select being false; the value flows through get_listing_config() into component state.

Implementation: controlpanel.py (new field), ajax.py (resolver + get_listing_config), view.py (default → None), profiles/default/metadata.xml (2700 → 2701), upgrades/{configure.zcml,handlers.py} (to_2701 re-imports the registry step).

--
I confirm I have tested the PR thoroughly and coded it according to [PEP8][1]
standards.

[1]: https://www.python.org/dev/peps/pep-0008
