### PR TITLE
Improve KeywordIndex column filtering: populate autocomplete and AND multiple values

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,6 +1,7 @@
 2.7.0 (unreleased)
 ------------------
 
+- #179 Fix empty filter autocomplete for multi-valued (KeywordIndex) metadata columns
 - #XXX Support label chips, click-to-filter, and label-aware saved filters
 - #176 Redesign TableColumnConfig as a searchable popover
 - #177 Refactor TextField to a modern ReactJS Component

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -1,7 +1,7 @@
 2.7.0 (unreleased)
 ------------------
 
-- #179 Fix empty filter autocomplete for multi-valued (KeywordIndex) metadata columns
+- #179 Improve KeywordIndex column filtering: populate autocomplete and AND multiple values
 - #XXX Support label chips, click-to-filter, and label-aware saved filters
 - #176 Redesign TableColumnConfig as a searchable popover
 - #177 Refactor TextField to a modern ReactJS Component

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -2,7 +2,7 @@
 ------------------
 
 - #179 Improve KeywordIndex column filtering: populate autocomplete and AND multiple values
-- #XXX Support label chips, click-to-filter, and label-aware saved filters
+- #178 Support label chips, click-to-filter, and label-aware saved filters
 - #176 Redesign TableColumnConfig as a searchable popover
 - #177 Refactor TextField to a modern ReactJS Component
 - #174 Add saved filter presets and listing filter refinements

--- a/src/senaite/app/listing/ajax.py
+++ b/src/senaite/app/listing/ajax.py
@@ -888,7 +888,14 @@ class AjaxListingView(BrowserView):
                 # Handle callable attributes
                 if callable(value):
                     value = value()
-                unique_values.add(value)
+                # Multi-valued metadata (e.g. KeywordIndex columns) holds a
+                # sequence per brain; expand it into its individual values
+                # so each one becomes a selectable filter option.
+                if isinstance(value, (list, tuple, set)):
+                    unique_values.update(
+                        v for v in value if v not in (None, ""))
+                else:
+                    unique_values.add(value)
             except Exception:
                 continue
 

--- a/src/senaite/app/listing/view.py
+++ b/src/senaite/app/listing/view.py
@@ -748,8 +748,15 @@ class ListingView(AjaxListingView):
                 # Field indexes: try exact match
                 query[index_name] = filter_value
             elif index_type == "KeywordIndex":
-                # Keyword indexes: search in list
-                query[index_name] = filter_value
+                # Keyword indexes: support multiple comma-separated values.
+                # When more than one is given every keyword must be present
+                # (AND), which lets the user narrow down by several values.
+                values = [v.strip() for v in filter_value.split(",")
+                          if v.strip()]
+                if len(values) > 1:
+                    query[index_name] = {"query": values, "operator": "and"}
+                else:
+                    query[index_name] = filter_value
             else:
                 # Default: try exact match to be safe
                 query[index_name] = filter_value


### PR DESCRIPTION
## Description

Two improvements that make `KeywordIndex` per-column filters fully usable.

> **Dependency:** this PR is required by senaite/senaite.core#2965 (*Filter samples by their analyses in the samples listing*), which consumes the KeywordIndex autocomplete and multi-value (AND) filtering added here. senaite.core#2965 should land together with / after this PR.

## Current behavior before PR

1. **Empty autocomplete**: when a filterable column's index is also exposed as a same-named metadata column, `get_unique_column_values` takes the metadata path and does `unique_values.add(value)`. For a `KeywordIndex` the per-brain value is a list (unhashable) → `TypeError`, swallowed by the bare `except` for every brain → the autocomplete shows no options. (The `labels` column avoided this only because its index `labels` and metadata `getLabels` differ in name, so it fell through to `index.uniqueValues()`.)
2. **Single value only**: a `KeywordIndex` column filter applied exactly one value, so the listing could not be narrowed by several keywords at once.

## Desired behavior after PR is merged

1. Multi-valued metadata (`list`/`tuple`/`set`) is expanded into its individual members, so each value becomes a selectable autocomplete option.
2. A `KeywordIndex` filter value containing several comma-separated keywords queries the index with all of them and the `and` operator, returning only rows that contain every selected keyword.

Together these let a consumer (e.g. senaite.core's `getAnalysesKeywords` column) offer keyword autocomplete and multi-keyword narrowing.